### PR TITLE
convert sgv to string

### DIFF
--- a/lib/pebble.js
+++ b/lib/pebble.js
@@ -49,7 +49,7 @@ function pebble (req, res) {
         }
         if (element) {
             var obj = {};
-            obj.sgv = scaleBg(element.sgv);
+            obj.sgv = scaleBg(element.sgv).toString( );
             obj.bgdelta = (next ? (scaleBg(element.sgv) - scaleBg(next.sgv) ) : 0);
             if (useMetricBg) {
                 obj.bgdelta = obj.bgdelta.toFixed(1);


### PR DESCRIPTION
On my new pebble with the installed app, the SGV value does not show
up unless it is a string type in the json.
